### PR TITLE
pytest setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 *.so
 .venv/
 chords_downloader.egg-info/
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ python -m venv .venv
 ```
 Install dependencies:
 ```powershell
-pip install requests numpy pandas
+pip install requests numpy pandas pytest
 ```
 Verify installation:
 ```powershell
@@ -67,6 +67,7 @@ Verify installation:
 requests --version
 numpy --version
 pandas --version
+pytest --version
 ```
 
 ## Available Portals

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests==2.32.5
 numpy==1.26.2
 pandas==2.3.2
+pytest==9.0.2

--- a/src/chords_downloader/chords_dataframes.py
+++ b/src/chords_downloader/chords_dataframes.py
@@ -34,11 +34,6 @@ def main(
         if time_window_start == "" or time_window_end == "":
             raise ValueError(f"Both the 'time_window_start' and 'time_window_end' variables must be populated to specify a collection timeframe.")
 
-    # portal_lookup = [
-    #     'barbados', 'trinidad', '3d-paws', 'calibration', 'fewsnet', 'kenya', 
-    #     'zimbabwe', 'dominican-republic', 'argentina', 'zambia', 'iitm', 'fiji',
-    #     'malawi', 'bahamas', 'somalia'
-    # ]
     from chords_downloader.resources.functions import PORTAL_LOOKUP
     if portal_name.lower() not in PORTAL_LOOKUP:
         raise ValueError(f"{portal_name} not found. Supported CHORDS portals include:\n{PORTAL_LOOKUP}")

--- a/src/chords_downloader/chords_local_download.py
+++ b/src/chords_downloader/chords_local_download.py
@@ -1,4 +1,5 @@
 import requests
+import warnings
 from json import dumps
 from json import loads
 import numpy as np
@@ -18,14 +19,12 @@ def main(portal_url:str, portal_name:str, data_path:Path, instrument_IDs:list, u
     if timestamp_start > timestamp_end:
             raise ValueError(f"Starting time cannot be after end time.\n\t\t\tStart: {timestamp_start}\t\tEnd: {timestamp_end}")
     if (timestamp_start < datetime.now() - timedelta(days=365*2)):
-            raise ValueError(
-                "\t ========================= WARNING ========================="\
-                f"\t timestamp_start before CHORDS cutoff (2 years): {timestamp_start}\n\t Will pull 2 year archive only.\n"
+            warnings.warn(
+                f"\t[WARNING]: timestamp_start before CHORDS cutoff (2 years): {timestamp_start}\n\t Will pull 2 year archive only.\n"
             )
     if (timestamp_end > datetime.now()) or (timestamp_start > datetime.now()):
-            raise ValueError(
-                "\t ========================= WARNING ========================="\
-                f"\t timestamp_start or timestamp_end in the future: {timestamp_start}\t{timestamp_end}\n\t Will pull up to today's date only.\n"
+            warnings.warn(
+                f"\t[WARNING]: timestamp_start or timestamp_end in the future: {timestamp_start}\t{timestamp_end}\n\t Will pull up to today's date only.\n"
             )
 
     if time_window_start != "" or time_window_end != "":

--- a/src/chords_downloader/chords_local_download.py
+++ b/src/chords_downloader/chords_local_download.py
@@ -17,12 +17,16 @@ def main(portal_url:str, portal_name:str, data_path:Path, instrument_IDs:list, u
     timestamp_end = datetime.strptime(end, format_str)
     if timestamp_start > timestamp_end:
             raise ValueError(f"Starting time cannot be after end time.\n\t\t\tStart: {timestamp_start}\t\tEnd: {timestamp_end}")
-    if timestamp_start < datetime.now() - timedelta(days=365*2):
-        print("\t ========================= WARNING =========================")
-        print(f"\t timestamp_start before CHORDS cutoff (2 years): {timestamp_start}\n\t Will pull 2 year archive only.\n")
-    if timestamp_end > datetime.now():
-        print("\t ========================= WARNING =========================")
-        print(f"\t timestamp_end in the future: {timestamp_end}\n\t Will pull up to today's date only.\n")
+    if (timestamp_start < datetime.now() - timedelta(days=365*2)):
+            raise ValueError(
+                "\t ========================= WARNING ========================="\
+                f"\t timestamp_start before CHORDS cutoff (2 years): {timestamp_start}\n\t Will pull 2 year archive only.\n"
+            )
+    if (timestamp_end > datetime.now()) or (timestamp_start > datetime.now()):
+            raise ValueError(
+                "\t ========================= WARNING ========================="\
+                f"\t timestamp_start or timestamp_end in the future: {timestamp_start}\t{timestamp_end}\n\t Will pull up to today's date only.\n"
+            )
 
     if time_window_start != "" or time_window_end != "":
         format_str = "%H:%M:%S"
@@ -33,11 +37,6 @@ def main(portal_url:str, portal_name:str, data_path:Path, instrument_IDs:list, u
         if time_window_start == "" or time_window_end == "":
             raise ValueError(f"Both the 'time_window_start' and 'time_window_end' variables must be populated to specify a collection timeframe.")
 
-    # portal_lookup = [
-    #     'barbados', 'trinidad', '3d-paws', 'calibration', 'fewsnet', 'kenya', 
-    #     'zimbabwe', 'dominican-republic', 'argentina', 'zambia', 'iitm', 'fiji',
-    #     'malawi', 'bahamas', 'somalia'
-    # ]
     from chords_downloader.resources.functions import PORTAL_LOOKUP 
     if portal_name.lower() not in PORTAL_LOOKUP:
         raise ValueError(f"{portal_name} not found. Supported CHORDS portals include:\n{PORTAL_LOOKUP}")

--- a/src/chords_downloader/main.py
+++ b/src/chords_downloader/main.py
@@ -7,16 +7,16 @@ from pathlib import Path
 from chords_downloader import chords_local_download, chords_dataframes
 
 
-PORTAL_URL = r"https://chords.url.com/"
-PORTAL_NAME = "Portal Name"
-DATA_PATH = Path("C://path//to//local//storage//") 
+PORTAL_URL = r"https://3d.chordsrt.com"
+PORTAL_NAME = "3D-PAWS"
+DATA_PATH = Path("/Users/rzieber/Downloads") 
 INSTRUMENT_IDS = [
     1,2,3
 ]
-USER_EMAIL = 'your@email.com'
-API_KEY = 'your-api-key' 
-START = 'YYYY-MM-DD HH:MM:SS' 
-END = 'YYYY-MM-DD HH:MM:SS'
+USER_EMAIL = 'rzieber@ucar.edu'
+API_KEY = 'pc7HQpcDipWsetaxmJ5t' 
+START = '2025-02-03 00:00:00' 
+END = '2025-02-03 22:59:59'
 
 def main():
     # To download csv's locally to your machine (most common):

--- a/src/chords_downloader/resources/functions.py
+++ b/src/chords_downloader/resources/functions.py
@@ -88,8 +88,10 @@ def load_portals(path: str | Path | None = None) -> list[str]:
         ]
     return portals
 
-PORTAL_LOOKUP = load_portals("src/chords_downloader/resources/dev/portals.txt")
-
+HERE = Path(__file__).parent
+PORTAL_LOOKUP = load_portals(
+    HERE / "dev" / "portals.txt"
+)
 
 """
 Helper function for build_headers() that checks if a header is in the known set of headers.

--- a/src/chords_downloader/tests/test_chords_local_download.py
+++ b/src/chords_downloader/tests/test_chords_local_download.py
@@ -1,0 +1,118 @@
+import pytest
+from datetime import timedelta, datetime
+from pathlib import Path
+from chords_downloader import chords_local_download as cld
+
+now = datetime.now()
+fmt = "%Y-%m-%d %H:%M:%S"
+
+def test_main_raises_when_start_after_end():
+    portal_url     = "https://example.com"
+    portal_name    = "3D-PAWS"
+    data_path      = Path("/tmp")
+    instrument_ids = [1]
+    user_email     = "test@example.com"
+    api_key        = "dummy"
+
+    start_dt = now - timedelta(hours=1)
+    end_dt   = now - timedelta(days=1)  
+    start    = start_dt.strftime(fmt)
+    end      = end_dt.strftime(fmt)
+
+    with pytest.raises(ValueError) as excinfo:
+        cld.main(
+            portal_url,
+            portal_name,
+            data_path,
+            instrument_ids,
+            user_email,
+            api_key,
+            start,
+            end,
+        )
+
+    assert "Starting time cannot be after end time" in str(excinfo.value)
+
+
+def test_main_raises_when_start_before_two_years():
+    portal_url     = "https://example.com"
+    portal_name    = "3D-PAWS"
+    data_path      = Path("/tmp")
+    instrument_ids = [1]
+    user_email     = "test@example.com"
+    api_key        = "dummy"
+    
+    start_dt = now - timedelta(days=365*3)
+    end_dt   = now - timedelta(days=1)  
+    start    = start_dt.strftime(fmt)
+    end      = end_dt.strftime(fmt)
+
+    with pytest.raises(ValueError) as excinfo:
+        cld.main(
+            portal_url,
+            portal_name,
+            data_path,
+            instrument_ids,
+            user_email,
+            api_key,
+            start,
+            end,
+        )
+    
+    assert "timestamp_start before CHORDS cutoff" in str(excinfo.value)
+
+
+def test_main_raises_when_start_in_future():
+    portal_url     = "https://example.com"
+    portal_name    = "3D-PAWS"
+    data_path      = Path("/tmp")
+    instrument_ids = [1]
+    user_email     = "test@example.com"
+    api_key        = "dummy"
+    
+    start_dt = now + timedelta(days=1)
+    end_dt   = now + timedelta(days=2)  
+    start    = start_dt.strftime(fmt)
+    end      = end_dt.strftime(fmt)
+
+    with pytest.raises(ValueError) as excinfo:
+        cld.main(
+            portal_url,
+            portal_name,
+            data_path,
+            instrument_ids,
+            user_email,
+            api_key,
+            start,
+            end,
+        )
+    
+    assert "timestamp_start or timestamp_end in the future" in str(excinfo.value)
+
+
+def test_main_raises_when_end_in_future():
+    portal_url     = "https://example.com"
+    portal_name    = "3D-PAWS"
+    data_path      = Path("/tmp")
+    instrument_ids = [1]
+    user_email     = "test@example.com"
+    api_key        = "dummy"
+    
+    start_dt = now - timedelta(hours=1)
+    end_dt   = now + timedelta(days=2)  
+    start    = start_dt.strftime(fmt)
+    end      = end_dt.strftime(fmt)
+
+    with pytest.raises(ValueError) as excinfo:
+        cld.main(
+            portal_url,
+            portal_name,
+            data_path,
+            instrument_ids,
+            user_email,
+            api_key,
+            start,
+            end,
+        )
+    
+    assert "timestamp_start or timestamp_end in the future" in str(excinfo.value)


### PR DESCRIPTION
rather than raise an error for out-of-bounds timestamps, want the script to continue to run with truncated timestamps

added warning handling in pytest and added warnings library in chords_local_download

