### PR TITLE
removing library specifications

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,10 +32,10 @@ classifiers = [
 ]
 
 dependencies = [
-    "numpy>=1.21.0,<1.25.0",      # RPi 3B compatible
-    "pandas>=1.1.5,<1.3.6",
-    "requests>=2.28.0,<3.0.0",
-    "python-dotenv>=0.20.1",
+    "numpy",     
+    "pandas",
+    "requests",
+    "python-dotenv",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
latest release doesn't need library specs only the RPi does